### PR TITLE
fig - fix mongo insufficient disk space issue

### DIFF
--- a/fig.yml
+++ b/fig.yml
@@ -13,6 +13,6 @@ rabbitmq:
 mongodb:
   image: mongo
   volumes:
-    - ./data/db:/data/db
+    - ./data:/data
   ports:
     - "27017:27017"


### PR DESCRIPTION
In OSX (boot2docker) while using fig to start mongo, redis and rabbitmq, I saw an issue when mongo would not start correctly. The error mentioned not having enough disk space for journals, however removing 'db' from the fig.yml config for mongo volumns fixes this issue.
