### PR TITLE
Removed -b option from demo deploy script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,15 @@ Then run the app
 $ (cd customers-stores/customers-ui; spring run app.groovy)
 ```
 
-## Running on Cloudfoundry
+## Running on Cloud Foundry
 
-Pre-requisites: the `cf` command line, Maven (3) and Java (1.7).
+Pre-requisites: 
+
+* Maven (3)
+* Java (1.8)
+* the `cf` CLI
+* Cloud Foundry with Java buildpack version 2.5 or greater (for Java 1.8 support)
+
 Clone the repository and initialize submodules:
 
 ```

--- a/demo_deploy.sh
+++ b/demo_deploy.sh
@@ -48,7 +48,7 @@ function deploy_app() {
     fi
 
     #TODO: using java8 because of temp requirement for spring-platform-bus
-    cf push $APP -m 1028m -b https://github.com/spring-io/java-buildpack -p $JARPATH --no-start
+    cf push $APP -m 1028m -p $JARPATH --no-start
     cf env $APP | grep SPRING_PROFILES_ACTIVE || cf set-env $APP SPRING_PROFILES_ACTIVE cloud
     cf env $APP | grep ENCRYPT_KEY || cf set-env $APP ENCRYPT_KEY deadbeef
     if [ "$PREFIX" != "" ]; then


### PR DESCRIPTION
The `demo_deploy.sh` script is currently using a very old fork of the Java buildpack for Java 8 compatibility. PWS uses a Java 8 compatible buildpack by default now, and a Java 8 compatible version can easily be added to a PCF deployment. 
